### PR TITLE
Include s&bux library as a github submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,22 +3,15 @@
 # https://git-scm.com/docs/gitignore
 
 # Auto-generated code editor files
-.vs/*
-.vscode/*
+**/.vs
+**/.vscode
+**/.idea
+**/obj
+**/Properties
+
 *.csproj
-obj/*
-Properties/*
-Libraries/*
-code/obj/*
-code/Properties/*
 *.sln
 
-# Editor Projects
-code/Editor/obj/*
-code/Editor/Properties/*
-code/Editor/*.sln
-code/Editor/.vs/*
-code/Editor/.vscode/*
 
 # Auto-generated asset related files
 *.generated.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Libraries/sbux.api"]
+	path = Libraries/sbux.api
+	url = https://github.com/s8bux/sbux-api


### PR DESCRIPTION
This embeds the s&bux repository to the donut repository.

![image](https://github.com/Softsplit/sbox-donut/assets/91832803/ac3ce030-6c6b-48ee-9410-f5e57c8ea662)
