### PR TITLE
Better message wrapping

### DIFF
--- a/Code/UI/Chat/ChatEntry.razor
+++ b/Code/UI/Chat/ChatEntry.razor
@@ -7,9 +7,10 @@
     {
         <img class="avatar" src=@($"avatar:{Entry.SteamId}") />
     }
-    <p class="name">@Entry.Name</p>
     <div class="message-content">
-        <p class="message">@Entry.Message</p>
+        <p class="name">@Entry.Name</p>
+        @*HACK: inline is not supported yet, so offset the message with the lenght of the username.*@
+        <p class="message">@( new string( ' ', Entry.Name.Length + 1 ) + Entry.Message )</p>
     </div>
 </root>
 

--- a/Code/UI/Chat/Chatbox.razor.scss
+++ b/Code/UI/Chat/Chatbox.razor.scss
@@ -9,7 +9,7 @@ p {
 }
 
 .rainbow {
-    > .name {
+    >> .name {
         animation-name: rainbowcycle;
         animation-duration: 4s;
         animation-iteration-count: infinite;
@@ -145,17 +145,13 @@ ChatEntry {
         text-shadow: 0 0 4px black;
     }
 
-    .name {
-        padding-left: 4px;
-        padding-right: 5px;
-        flex-shrink: 0;
-        align-self: center;
-        max-width: 150px;
-        color: #ccf45a;
-    }
-
     .message-content {
+        .name {
+            position: absolute;
+            color: #ccf45a;
+        }
         .message {
+            white-space: pre;
         }
     }
 


### PR DESCRIPTION
Makes chat entries with long names more readable.

Temporary solution until `display: inline-flex;` is supported (never).

| Before | After |
|--------|--------|
| ![image](https://github.com/Softsplit/sbox-donut/assets/91832803/6bfe2e2d-405f-413a-89af-172cc777a59c) | ![image](https://github.com/Softsplit/sbox-donut/assets/91832803/edd381ea-48e0-4a69-9b0a-c5609ce675cd) | 
